### PR TITLE
Fix typo in jupyterhub config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,7 +50,7 @@ sphinx:
           type: fontawesome
       launch_buttons:
         binderhub_url: https://binder.projectpythia.org
-        jupyterhub_rl: https://nimbus6.llnl.gov
+        jupyterhub_url: https://nimbus6.llnl.gov
         notebook_interface: jupyterlab
       extra_navbar: |
         Theme by <a href="https://projectpythia.org">Project Pythia</a>.<br><br>


### PR DESCRIPTION
Fix the configuration file pointing the jupyterhub
