### PR TITLE
FIX: Bring back numpy pin

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - pyviz
 dependencies:
   - python<3.12
-  - numpy
+  - numpy<1.24.0
   - matplotlib
   - pandas
   - xarray


### PR DESCRIPTION
Go back to previous version of numpy that is not leading to numba build errors
