### PR TITLE
FIX: Update link to the ESGF2-US Jupyterhub

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,7 +50,7 @@ sphinx:
           type: fontawesome
       launch_buttons:
         binderhub_url: https://binder.projectpythia.org
-        jupyterhub_url: https://nimbus6.llnl.gov
+        jupyterhub_url: https://nimbus.llnl.gov
         notebook_interface: jupyterlab
       extra_navbar: |
         Theme by <a href="https://projectpythia.org">Project Pythia</a>.<br><br>


### PR DESCRIPTION
Fix the link to the ESGF2-US Jupyterhub
